### PR TITLE
fix(generate-app ks): Fix empty path on Kustomization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 bin/
 *.py
+
+cmd/flamingo/flamingo

--- a/cmd/flamingo/generate_app_ks.go
+++ b/cmd/flamingo/generate_app_ks.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
+	"text/template"
+
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
-	"text/template"
 )
 
 const ksAppTemplate = `---
@@ -88,7 +89,10 @@ func generateKustomizationApp(c client.Client, appName, objectName string, kindN
 	params.WorkloadType = kindName
 	params.SourceType = sourceKind
 
-	params.Path = object.Spec.Path
+	params.Path = "."
+	if object.Spec.Path != "" {
+		params.Path = object.Spec.Path
+	}
 
 	switch sourceKind {
 	case sourcev1.GitRepositoryKind:

--- a/cmd/flamingo/generate_app_ks.go
+++ b/cmd/flamingo/generate_app_ks.go
@@ -89,6 +89,7 @@ func generateKustomizationApp(c client.Client, appName, objectName string, kindN
 	params.WorkloadType = kindName
 	params.SourceType = sourceKind
 
+	// The default path is '.' unless provided by the object
 	params.Path = "."
 	if object.Spec.Path != "" {
 		params.Path = object.Spec.Path


### PR DESCRIPTION
# What

This fixes a bug where there is an Empty path `spec.path` for a Flux Kustomization

# Testing

Create a test valid kustomization, this is a valid kustomization

```yaml
apiVersion: kustomize.toolkit.fluxcd.io/v1
kind: Kustomization
metadata:
  name: example-components
  namespace: example-system
spec:
  force: false
  interval: 24h
  prune: true
  retryInterval: 5m
  serviceAccountName: kustomize-controller
  sourceRef:
    kind: OCIRepository
    name: example-components
  ```
  
  Notice that this does not have a `spec.path` because flux will take the default of `.` as the default path if there is none
  
  Attempt to run flamingo generate on this kustomization against your kubernetes cluster
  
  ```
  $  flamingo generate-app \
  --app-name=example-components \
  -n example-system ks/example-components
► applying generated application example-components in argocd namespace
✗ install failed: Application/argocd/example-components dry-run failed, reason: Invalid: Application.argoproj.io "flux-components" is invalid: spec.source.path: Invalid value: "null": spec.source.path in body must be of type string: "null"
  ```
  
  If you use `--export`, you will notice that the `spec.source.path` is empty
  
  ```
  $ flamingo generate-app \
  --app-name=flux-components \
  -n flux-system ks/flux-components --export
 ```
 
 ```yaml
---
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: example-components
  namespace: argocd
spec:
  destination:
    namespace: example-system
    server: https://kubernetes.default.svc
  project: default
  source:
    path:
    repoURL: oci://ghcr.io/fluxcd/flux-manifests
    targetRevision: "~2"
  syncPolicy:
    syncOptions:
    - ApplyOutOfSyncOnly=true
    - FluxSubsystem=true
  ```
 
  
With this change, this `spec.source.path` will default to `.` in the event that the given object does not have a path.

You can see this be able to apply here
  
  ```
  $ ~/src/github/Mitsuwa/flamingo/cmd/flamingo/flamingo generate-app \
  --app-name=example-components \
  -n flux-system ks/example-components
► applying generated application example-components in argocd namespace
application.argoproj.io/example-components created
```

I have also confirmed in argo that the app is displayed and the tree is built out appropriately